### PR TITLE
Add support for token-based authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,66 @@ For use within functions:
 * ReadSecret() - Read a named secret from within an OpenFaaS Function
 * ReadSecrets() - Read all available secrets returning a queryable map
 
+## Usage
+
+```go
+import "github.com/openfaas/go-sdk"
+```
+
+Construct a new OpenFaaS client and use it to access the OpenFaaS gateway API.
+
+```go
+gatewayURL, _ := url.Parse("http://127.0.0.1:8080")
+auth := &sdk.BasicAuth{
+    Username: username,
+    Password: password,
+}
+
+client := sdk.NewClient(gatewayURL, auth, http.DefaultClient)
+
+namespace, err := client.GetNamespaces()
+```
+
+### Authentication with IAM
+
+To authenticate with an OpenFaaS deployment that has [Identity and Access Management (IAM)](https://docs.openfaas.com/openfaas-pro/iam/overview/) enabled, the client needs to exchange an ID token for an OpenFaaS ID token.
+
+To get a token that can be exchanged for an OpenFaaS token you need to implement the `TokenSource` interface.
+
+This is an example of a token source that gets a service account token mounted into a pod with [ServiceAccount token volume projection](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#serviceaccount-token-volume-projection).
+
+```go
+type ServiceAccountTokenSource struct{}
+
+func (ts *ServiceAccountTokenSource) Token() (string, error) {
+	tokenMountPath := getEnv("token_mount_path", "/var/secrets/tokens")
+	if len(tokenMountPath) == 0 {
+		return "", fmt.Errorf("invalid token_mount_path specified for reading the service account token")
+	}
+
+	idTokenPath := path.Join(tokenMountPath, "openfaas-token")
+	idToken, err := os.ReadFile(idTokenPath)
+	if err != nil {
+		return "", fmt.Errorf("unable to load service account token: %s", err)
+	}
+
+	return string(idToken), nil
+}
+```
+
+The service account token returned by the `TokenSource` is automatically exchanged for an OpenFaaS token that is then used in the Authorization header for all requests made to the API.
+
+If the OpenFaaS token is expired the `TokenSource` is asked for a token and the token exchange will run again.
+
+```go
+gatewayURL, _ := url.Parse("https://gw.openfaas.example.com")
+
+auth := &sdk.TokenAuth{
+    TokenURL "https://gw.openfaas.example.com/oauth/token",
+    TokenSource: &ServiceAccountTokenSource{}
+}
+
+client := sdk.NewClient(gatewayURL, auth, http.DefaultClient)
+```
+
 License: MIT

--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,62 @@
+package sdk
+
+import (
+	"net/http"
+	"sync"
+)
+
+// BasicAuth basic authentication for the the OpenFaaS client
+type BasicAuth struct {
+	Username string
+	Password string
+}
+
+// Set Authorization Basic header on request
+func (auth *BasicAuth) Set(req *http.Request) error {
+	req.SetBasicAuth(auth.Username, auth.Password)
+	return nil
+}
+
+// A TokenSource is anything that can return an OIDC ID token that can be exchanged for
+// an OpenFaaS token.
+type TokenSource interface {
+	// Token returns a token or an error.
+	Token() (string, error)
+}
+
+// TokenAuth bearer token authentication for OpenFaaS deployments with OpenFaaS IAM
+// enabled.
+type TokenAuth struct {
+	// TokenURL represents the OpenFaaS gateways token endpoint URL.
+	TokenURL string
+
+	// TokenSource used to get an ID token that can be exchanged for an OpenFaaS ID token.
+	TokenSource TokenSource
+
+	lock  sync.Mutex // guards token
+	token *Token
+}
+
+// Set Authorization Bearer header on request.
+// Set validates the token expiry on each call. If it's expired it will exchange
+// an ID token from the TokenSource for a new OpenFaaS token.
+func (a *TokenAuth) Set(req *http.Request) error {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	if a.token == nil || a.token.Expired() {
+		idToken, err := a.TokenSource.Token()
+		if err != nil {
+			return err
+		}
+
+		token, err := ExchangeIDToken(a.TokenURL, idToken)
+		if err != nil {
+			return err
+		}
+		a.token = token
+	}
+
+	req.Header.Add("Authorization", "Bearer "+a.token.IDToken)
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@ go 1.19
 
 require github.com/openfaas/faas-provider v0.19.1
 
-require github.com/google/go-cmp v0.5.9 // indirect
+require github.com/google/go-cmp v0.5.9

--- a/token.go
+++ b/token.go
@@ -1,0 +1,98 @@
+package sdk
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// expiryDelta determines how much earlier a token should be considered
+// expired than its actual expiration time. It is used to avoid late
+// expirations due to client-server time mismatches.
+const expiryDelta = 10 * time.Second
+
+// Token represents an OpenFaaS ID token
+type Token struct {
+	// IDToken is the OIDC access token that authorizes and authenticates
+	// the requests.
+	IDToken string
+
+	// Expiry is the expiration time of the access token.
+	//
+	// A zero value means the token never expires.
+	Expiry time.Time
+}
+
+// Expired reports whether the token is expired.
+func (t *Token) Expired() bool {
+	if t.Expiry.IsZero() {
+		return false
+	}
+
+	return t.Expiry.Round(0).Add(-expiryDelta).Before(time.Now())
+}
+
+type tokenJSON struct {
+	AccessToken string `json:"access_token"`
+	IDToken     string `json:"id_token"`
+
+	TokenType string `json:"token_type"`
+
+	ExpiresIn int `json:"expires_in"`
+}
+
+func (t *tokenJSON) expiry() (exp time.Time) {
+	if v := t.ExpiresIn; v != 0 {
+		return time.Now().Add(time.Duration(v) * time.Second)
+	}
+	return
+}
+
+// Exchange an ID Token for OpenFaaS token
+func ExchangeIDToken(tokenURL, rawIDToken string) (*Token, error) {
+	v := url.Values{}
+	v.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
+	v.Set("subject_token_type", "urn:ietf:params:oauth:token-type:id_token")
+	v.Set("subject_token", rawIDToken)
+
+	u, _ := url.Parse(tokenURL)
+
+	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(v.Encode()))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.Body != nil {
+		defer res.Body.Close()
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("cannot fetch token: %v", err)
+	}
+
+	if code := res.StatusCode; code < 200 || code > 299 {
+		return nil, fmt.Errorf("cannot fetch token: %v\nResponse: %s", res.Status, body)
+	}
+
+	tj := &tokenJSON{}
+	if err := json.Unmarshal(body, tj); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal token: %s", err)
+	}
+
+	return &Token{
+		IDToken: tj.AccessToken,
+		Expiry:  tj.expiry(),
+	}, nil
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Basic auth was the only supported authentication method. This change adds a ClientAuth interface to support multiple authentication methods.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [ ] My issue has received approval from the maintainers or lead with the `design/approved` label

This is required to use the sdk with OpenFaaS deployments that have OpenFaaS IAM enabled.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Used this version if the SDK to authenticate OpenFaaS connectors with an IAM enabled cluster.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Users of the SDK should now implement the` ClientAuth` interface to authenticate instead of passing `BasicAuthCredentials`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.