### PR TITLE
Add reference for ServiceAccountTokenSource helper in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ For use within functions:
 * ReadSecret() - Read a named secret from within an OpenFaaS Function
 * ReadSecrets() - Read all available secrets returning a queryable map
 
+Authentication helpers (See: [Authentication with IAM](#authentication-with-iam)):
+
+* ServiceAccountTokenSource - An implementation of the TokenSource interface to get an ID token by reading a Kubernetes projected service account token from `/var/secrets/tokens/openfaas-token` or the path set by the `token_mount_path` environment
+variable.
+
 ## Usage
 
 ```go


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add a reference section for authentication helpers in the README.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Document auth helpers like: `ServiceAccountTokenSource`

Resolves: https://github.com/openfaas/go-sdk/pull/7#issuecomment-1651268512


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.