### PR TITLE
Add example for federated gateway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/e2e_test.go

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ func Test_ClientCredentials(t *testing.T) {
 		t.Fatal("token is empty")
 	}
 
-	u, _ := url.Parse("https://fed-gw.exit.welteki.dev")
+	u, _ := url.Parse("https://fed-gw.example.com")
 
 	client := NewClient(u, &ClientCredentialsAuth{tokenSource: auth}, http.DefaultClient)
 

--- a/README.md
+++ b/README.md
@@ -78,4 +78,42 @@ auth := &sdk.TokenAuth{
 client := sdk.NewClient(gatewayURL, auth, http.DefaultClient)
 ```
 
+### Authentication with Federated Gateway
+
+```go
+func Test_ClientCredentials(t *testing.T) {
+	clientID := ""
+	clientSecret := ""
+	tokenURL := "https://keycloak.example.com/realms/openfaas/protocol/openid-connect/token"
+	scope := "email"
+	grantType := "client_credentials"
+
+	auth := NewClientCredentialsTokenSource(clientID, clientSecret, tokenURL, scope, grantType)
+
+	token, err := auth.Token()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if token == "" {
+		t.Fatal("token is empty")
+	}
+
+	u, _ := url.Parse("https://fed-gw.exit.welteki.dev")
+
+	client := NewClient(u, &ClientCredentialsAuth{tokenSource: auth}, http.DefaultClient)
+
+	fns, err := client.GetFunctions(context.Background(), "openfaas-fn")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(fns) == 0 {
+		t.Fatal("no functions found")
+	}
+}
+```
+
+## License
+
 License: MIT

--- a/basic_auth.go
+++ b/basic_auth.go
@@ -1,0 +1,17 @@
+package sdk
+
+import (
+	"net/http"
+)
+
+// BasicAuth basic authentication for the the OpenFaaS client
+type BasicAuth struct {
+	Username string
+	Password string
+}
+
+// Set Authorization Basic header on request
+func (auth *BasicAuth) Set(req *http.Request) error {
+	req.SetBasicAuth(auth.Username, auth.Password)
+	return nil
+}

--- a/client.go
+++ b/client.go
@@ -161,7 +161,7 @@ func (s *Client) GetInfo(ctx context.Context) (SystemInfo, error) {
 }
 
 // GetFunction gives a richer payload than GetFunctions, but for a specific function
-func (s *Client) GetFunction(ctx context.Context, name, namespace string) (types.FunctionDeployment, error) {
+func (s *Client) GetFunction(ctx context.Context, name, namespace string) (types.FunctionStatus, error) {
 	u := s.GatewayURL
 
 	u.Path = "/system/function/" + name
@@ -174,18 +174,18 @@ func (s *Client) GetFunction(ctx context.Context, name, namespace string) (types
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
-		return types.FunctionDeployment{}, fmt.Errorf("unable to create request for %s, error: %w", u.String(), err)
+		return types.FunctionStatus{}, fmt.Errorf("unable to create request for %s, error: %w", u.String(), err)
 	}
 
 	if s.ClientAuth != nil {
 		if err := s.ClientAuth.Set(req); err != nil {
-			return types.FunctionDeployment{}, fmt.Errorf("unable to set Authorization header: %w", err)
+			return types.FunctionStatus{}, fmt.Errorf("unable to set Authorization header: %w", err)
 		}
 	}
 
 	res, err := s.Client.Do(req)
 	if err != nil {
-		return types.FunctionDeployment{}, fmt.Errorf("unable to make HTTP request: %w", err)
+		return types.FunctionStatus{}, fmt.Errorf("unable to make HTTP request: %w", err)
 	}
 
 	if res.Body != nil {
@@ -194,13 +194,13 @@ func (s *Client) GetFunction(ctx context.Context, name, namespace string) (types
 
 	body, _ := io.ReadAll(res.Body)
 
-	functions := types.FunctionDeployment{}
-	if err := json.Unmarshal(body, &functions); err != nil {
-		return types.FunctionDeployment{},
+	function := types.FunctionStatus{}
+	if err := json.Unmarshal(body, &function); err != nil {
+		return types.FunctionStatus{},
 			fmt.Errorf("unable to unmarshal value: %q, error: %w", string(body), err)
 	}
 
-	return functions, nil
+	return function, nil
 }
 
 func (s *Client) Deploy(ctx context.Context, spec types.FunctionDeployment) (int, error) {

--- a/client_credentials_auth.go
+++ b/client_credentials_auth.go
@@ -11,18 +11,14 @@ import (
 	"time"
 )
 
-type ClientCredentialsTokenSource struct {
-	clientID     string
-	clientSecret string
-	tokenURL     string
-	scope        string
-	grantType    string
-	token        *ClientCredentialsToken
-	lock         sync.RWMutex
+type ClientCredentialsAuth struct {
+	tokenSource TokenSource
 }
 
-type ClientCredentialsAuth struct {
-	tokenSource *ClientCredentialsTokenSource
+func NewClientCredentialsAuth(ts TokenSource) *ClientCredentialsAuth {
+	return &ClientCredentialsAuth{
+		tokenSource: ts,
+	}
 }
 
 func (cca *ClientCredentialsAuth) Set(req *http.Request) error {
@@ -34,7 +30,21 @@ func (cca *ClientCredentialsAuth) Set(req *http.Request) error {
 	return nil
 }
 
-func NewClientCredentialsTokenSource(clientID, clientSecret, tokenURL, scope, grantType string) *ClientCredentialsTokenSource {
+// ClientCredentialsTokenSource can be used to obtain
+// an access token using the client credentials grant type.
+// Tested with Keycloak's token endpoint, additional changes may
+// be required for additional OIDC token endpoints.
+type ClientCredentialsTokenSource struct {
+	clientID     string
+	clientSecret string
+	tokenURL     string
+	scope        string
+	grantType    string
+	token        *ClientCredentialsToken
+	lock         sync.RWMutex
+}
+
+func NewClientCredentialsTokenSource(clientID, clientSecret, tokenURL, scope, grantType string) TokenSource {
 	return &ClientCredentialsTokenSource{
 		clientID:     clientID,
 		clientSecret: clientSecret,
@@ -108,6 +118,9 @@ func obtainClientCredentialsToken(clientID, clientSecret, tokenURL, scope, grant
 	return token, nil
 }
 
+// ClientCredentialsToken represents an access_token
+// obtained through the client credentials grant type.
+// This token is not associated with a human user.
 type ClientCredentialsToken struct {
 	AccessToken string `json:"access_token"`
 	TokenType   string `json:"token_type"`

--- a/client_credentials_auth.go
+++ b/client_credentials_auth.go
@@ -1,0 +1,129 @@
+package sdk
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+)
+
+type ClientCredentialsTokenSource struct {
+	clientID     string
+	clientSecret string
+	tokenURL     string
+	scope        string
+	grantType    string
+	token        *ClientCredentialsToken
+	lock         sync.RWMutex
+}
+
+type ClientCredentialsAuth struct {
+	tokenSource *ClientCredentialsTokenSource
+}
+
+func (cca *ClientCredentialsAuth) Set(req *http.Request) error {
+	token, err := cca.tokenSource.Token()
+	if err != nil {
+		return err
+	}
+	req.Header.Add("Authorization", "Bearer "+token)
+	return nil
+}
+
+func NewClientCredentialsTokenSource(clientID, clientSecret, tokenURL, scope, grantType string) *ClientCredentialsTokenSource {
+	return &ClientCredentialsTokenSource{
+		clientID:     clientID,
+		clientSecret: clientSecret,
+		tokenURL:     tokenURL,
+		scope:        scope,
+		grantType:    grantType,
+	}
+}
+
+func (ts *ClientCredentialsTokenSource) Token() (string, error) {
+	ts.lock.RLock()
+	expired := ts.token == nil || ts.token.Expired()
+
+	if expired {
+		ts.lock.RUnlock()
+
+		token, err := obtainClientCredentialsToken(ts.clientID, ts.clientSecret, ts.tokenURL, ts.scope, ts.grantType)
+		if err != nil {
+			return "", err
+		}
+
+		ts.lock.Lock()
+		ts.token = token
+		ts.lock.Unlock()
+
+		return token.AccessToken, nil
+	}
+
+	ts.lock.RUnlock()
+	return ts.token.AccessToken, nil
+}
+
+func obtainClientCredentialsToken(clientID, clientSecret, tokenURL, scope, grantType string) (*ClientCredentialsToken, error) {
+
+	reqBody := url.Values{}
+	reqBody.Set("client_id", clientID)
+	reqBody.Set("client_secret", clientSecret)
+	reqBody.Set("grant_type", grantType)
+	reqBody.Set("scope", scope)
+
+	buffer := []byte(reqBody.Encode())
+
+	req, err := http.NewRequest(http.MethodPost, tokenURL, bytes.NewBuffer(buffer))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	var body []byte
+	if res.Body != nil {
+		defer res.Body.Close()
+		body, _ = io.ReadAll(res.Body)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code %d, body: %s", res.StatusCode, string(body))
+	}
+
+	token := &ClientCredentialsToken{}
+	if err := json.Unmarshal(body, token); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal token: %s", err)
+	}
+
+	token.ObtainedAt = time.Now()
+
+	return token, nil
+}
+
+type ClientCredentialsToken struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
+	ObtainedAt  time.Time
+}
+
+// Expired returns true if the token is expired
+// or if the expiry time is not known.
+// The token will always expire 10s early to avoid
+// clock skew.
+func (t *ClientCredentialsToken) Expired() bool {
+	if t.ExpiresIn == 0 {
+		return false
+	}
+	expiry := t.ObtainedAt.Add(time.Duration(t.ExpiresIn) * time.Second).Add(-expiryDelta)
+
+	return expiry.Before(time.Now())
+}

--- a/exchange.go
+++ b/exchange.go
@@ -1,0 +1,57 @@
+package sdk
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// Exchange an OIDC ID Token from an IdP for OpenFaaS token
+// using the token exchange grant type.
+// tokenURL should be the OpenFaaS token endpoint within the internal OIDC service
+func ExchangeIDToken(tokenURL, rawIDToken string) (*Token, error) {
+	v := url.Values{}
+	v.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
+	v.Set("subject_token_type", "urn:ietf:params:oauth:token-type:id_token")
+	v.Set("subject_token", rawIDToken)
+
+	u, _ := url.Parse(tokenURL)
+
+	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(v.Encode()))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.Body != nil {
+		defer res.Body.Close()
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("cannot fetch token: %v", err)
+	}
+
+	if code := res.StatusCode; code < 200 || code > 299 {
+		return nil, fmt.Errorf("cannot fetch token: %v\nResponse: %s", res.Status, body)
+	}
+
+	tj := &tokenJSON{}
+	if err := json.Unmarshal(body, tj); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal token: %s", err)
+	}
+
+	return &Token{
+		IDToken: tj.AccessToken,
+		Expiry:  tj.expiry(),
+	}, nil
+}

--- a/iam_auth.go
+++ b/iam_auth.go
@@ -8,18 +8,6 @@ import (
 	"sync"
 )
 
-// BasicAuth basic authentication for the the OpenFaaS client
-type BasicAuth struct {
-	Username string
-	Password string
-}
-
-// Set Authorization Basic header on request
-func (auth *BasicAuth) Set(req *http.Request) error {
-	req.SetBasicAuth(auth.Username, auth.Password)
-	return nil
-}
-
 // A TokenSource is anything that can return an OIDC ID token that can be exchanged for
 // an OpenFaaS token.
 type TokenSource interface {

--- a/token.go
+++ b/token.go
@@ -1,12 +1,6 @@
 package sdk
 
 import (
-	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
-	"net/url"
-	"strings"
 	"time"
 )
 
@@ -51,49 +45,4 @@ func (t *tokenJSON) expiry() (exp time.Time) {
 		return time.Now().Add(time.Duration(v) * time.Second)
 	}
 	return
-}
-
-// Exchange an ID Token for OpenFaaS token
-func ExchangeIDToken(tokenURL, rawIDToken string) (*Token, error) {
-	v := url.Values{}
-	v.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
-	v.Set("subject_token_type", "urn:ietf:params:oauth:token-type:id_token")
-	v.Set("subject_token", rawIDToken)
-
-	u, _ := url.Parse(tokenURL)
-
-	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(v.Encode()))
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	res, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	if res.Body != nil {
-		defer res.Body.Close()
-	}
-
-	body, err := io.ReadAll(res.Body)
-	if err != nil {
-		return nil, fmt.Errorf("cannot fetch token: %v", err)
-	}
-
-	if code := res.StatusCode; code < 200 || code > 299 {
-		return nil, fmt.Errorf("cannot fetch token: %v\nResponse: %s", res.Status, body)
-	}
-
-	tj := &tokenJSON{}
-	if err := json.Unmarshal(body, tj); err != nil {
-		return nil, fmt.Errorf("unable to unmarshal token: %s", err)
-	}
-
-	return &Token{
-		IDToken: tj.AccessToken,
-		Expiry:  tj.expiry(),
-	}, nil
 }

--- a/token.go
+++ b/token.go
@@ -27,7 +27,8 @@ type Token struct {
 	Expiry time.Time
 }
 
-// Expired reports whether the token is expired.
+// Expired reports whether the token is expired, and will start
+// to return false 10s before the actual expiration time.
 func (t *Token) Expired() bool {
 	if t.Expiry.IsZero() {
 		return false


### PR DESCRIPTION
## Description

Add example for federated gateway

## Why is this needed

Adds client credentials source, with caching for if a token is requested several times before expiry.

Part of [Federated Gateway](https://docs.openfaas.com/openfaas-pro/federated-gateway/#federated-gateway) feature.

Example added to README for usage, tested with federated gateway deployed by @welteki



```go
func Test_ClientCredentials(t *testing.T) {
	clientID := ""
	clientSecret := ""
	tokenURL := "https://keycloak.example.com/realms/openfaas/protocol/openid-connect/token"
	scope := "email"
	grantType := "client_credentials"

	auth := NewClientCredentialsTokenSource(clientID, clientSecret, tokenURL, scope, grantType)

	token, err := auth.Token()
	if err != nil {
		t.Fatal(err)
	}

	if token == "" {
		t.Fatal("token is empty")
	}

	u, _ := url.Parse("https://fed-gw.exit.welteki.dev")

	client := NewClient(u, &ClientCredentialsAuth{tokenSource: auth}, http.DefaultClient)

	fns, err := client.GetFunctions(context.Background(), "openfaas-fn")
	if err != nil {
		t.Fatal(err)
	}

	if len(fns) == 0 {
		t.Fatal("no functions found")
	}
}
``` 