### PR TITLE
Add namespace support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,24 @@
+name: test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    env:
+      GO111MODULE: off
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 1
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.20.x
+
+      - name: test
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+export GO111MODULE=on
+
+.PHONY: all
+all: test
+
+.PHONY: test
+test:
+	CGO_ENABLED=0 go test ./...

--- a/client.go
+++ b/client.go
@@ -81,6 +81,221 @@ func (s *Client) GetNamespaces(ctx context.Context) ([]string, error) {
 	return namespaces, err
 }
 
+// GetNamespaces get openfaas namespaces
+func (s *Client) GetNamespace(ctx context.Context, namespace string) (types.FunctionNamespace, error) {
+	u := s.GatewayURL
+	u.Path = fmt.Sprintf("/system/namespace/%s", namespace)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return types.FunctionNamespace{}, fmt.Errorf("unable to create request for %s, error: %w", u.String(), err)
+	}
+
+	if s.ClientAuth != nil {
+		if err := s.ClientAuth.Set(req); err != nil {
+			return types.FunctionNamespace{}, fmt.Errorf("unable to set Authorization header: %w", err)
+		}
+	}
+
+	res, err := s.Client.Do(req)
+	if err != nil {
+		return types.FunctionNamespace{}, fmt.Errorf("unable to make HTTP request: %w", err)
+	}
+
+	if res.Body != nil {
+		defer res.Body.Close()
+	}
+	body, _ := io.ReadAll(res.Body)
+
+	switch res.StatusCode {
+	case http.StatusOK:
+		fnNamespace := types.FunctionNamespace{}
+		if err := json.Unmarshal(body, &fnNamespace); err != nil {
+			return types.FunctionNamespace{},
+				fmt.Errorf("unable to unmarshal value: %q, error: %w", string(body), err)
+		}
+		return fnNamespace, err
+
+	case http.StatusNotFound:
+		return types.FunctionNamespace{}, fmt.Errorf("namespace %s not found", namespace)
+
+	case http.StatusUnauthorized:
+		return types.FunctionNamespace{}, fmt.Errorf("unauthorized action, please setup authentication for this server")
+
+	default:
+		return types.FunctionNamespace{}, fmt.Errorf("unexpected status code: %d, message: %q", res.StatusCode, string(body))
+	}
+}
+
+// CreateNamespace creates a namespace
+func (s *Client) CreateNamespace(ctx context.Context, spec types.FunctionNamespace) (int, error) {
+
+	// set openfaas label
+	if spec.Labels == nil {
+		spec.Labels = map[string]string{}
+	}
+	spec.Labels["openfaas"] = "1"
+
+	bodyBytes, err := json.Marshal(spec)
+	if err != nil {
+		return http.StatusBadRequest, err
+	}
+
+	bodyReader := bytes.NewReader(bodyBytes)
+
+	u := s.GatewayURL
+	u.Path = "/system/namespace/"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bodyReader)
+	if err != nil {
+		return http.StatusBadGateway, err
+	}
+
+	if s.ClientAuth != nil {
+		if err := s.ClientAuth.Set(req); err != nil {
+			return http.StatusInternalServerError, fmt.Errorf("unable to set Authorization header: %w", err)
+		}
+	}
+
+	res, err := s.Client.Do(req)
+	if err != nil {
+		return http.StatusBadGateway, err
+	}
+
+	var body []byte
+	if res.Body != nil {
+		defer res.Body.Close()
+		body, _ = io.ReadAll(res.Body)
+	}
+
+	switch res.StatusCode {
+	case http.StatusAccepted, http.StatusOK, http.StatusCreated:
+		return res.StatusCode, nil
+
+	case http.StatusUnauthorized:
+		return res.StatusCode, fmt.Errorf("unauthorized action, please setup authentication for this server")
+
+	default:
+		return res.StatusCode, fmt.Errorf("unexpected status code: %d, message: %q", res.StatusCode, string(body))
+	}
+}
+
+// UpdateNamespace updates a namespace
+func (s *Client) UpdateNamespace(ctx context.Context, spec types.FunctionNamespace) (int, error) {
+
+	// set openfaas label
+	if spec.Labels == nil {
+		spec.Labels = map[string]string{}
+	}
+	spec.Labels["openfaas"] = "1"
+
+	bodyBytes, err := json.Marshal(spec)
+	if err != nil {
+		return http.StatusBadRequest, err
+	}
+
+	bodyReader := bytes.NewReader(bodyBytes)
+
+	u := s.GatewayURL
+	u.Path = fmt.Sprintf("/system/namespace/%s", spec.Name)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, u.String(), bodyReader)
+	if err != nil {
+		return http.StatusBadGateway, err
+	}
+
+	if s.ClientAuth != nil {
+		if err := s.ClientAuth.Set(req); err != nil {
+			return http.StatusInternalServerError, fmt.Errorf("unable to set Authorization header: %w", err)
+		}
+	}
+
+	res, err := s.Client.Do(req)
+	if err != nil {
+		return http.StatusBadGateway, err
+	}
+
+	var body []byte
+	if res.Body != nil {
+		defer res.Body.Close()
+		body, _ = io.ReadAll(res.Body)
+	}
+
+	switch res.StatusCode {
+	case http.StatusAccepted, http.StatusOK, http.StatusCreated:
+		return res.StatusCode, nil
+
+	case http.StatusNotFound:
+		return res.StatusCode, fmt.Errorf("namespace %s not found", spec.Name)
+
+	case http.StatusUnauthorized:
+		return res.StatusCode, fmt.Errorf("unauthorized action, please setup authentication for this server")
+
+	default:
+		return res.StatusCode, fmt.Errorf("unexpected status code: %d, message: %q", res.StatusCode, string(body))
+	}
+}
+
+// DeleteNamespace deletes a namespace
+func (s *Client) DeleteNamespace(ctx context.Context, namespace string) error {
+
+	delReq := types.FunctionNamespace{
+		Name: namespace,
+		Labels: map[string]string{
+			"openfaas": "1",
+		},
+	}
+
+	var err error
+
+	bodyBytes, _ := json.Marshal(delReq)
+	bodyReader := bytes.NewReader(bodyBytes)
+
+	u := s.GatewayURL
+	u.Path = fmt.Sprintf("/system/namespace/%s", namespace)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, u.String(), bodyReader)
+	if err != nil {
+		return fmt.Errorf("cannot connect to OpenFaaS on URL: %s, error: %s", u.String(), err)
+	}
+
+	if s.ClientAuth != nil {
+		if err := s.ClientAuth.Set(req); err != nil {
+			return fmt.Errorf("unable to set Authorization header: %w", err)
+		}
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("cannot connect to OpenFaaS on URL: %s, error: %s", s.GatewayURL, err)
+
+	}
+
+	if res.Body != nil {
+		defer res.Body.Close()
+	}
+
+	switch res.StatusCode {
+	case http.StatusAccepted, http.StatusOK, http.StatusCreated:
+		break
+
+	case http.StatusNotFound:
+		return fmt.Errorf("namespace %s not found", namespace)
+
+	case http.StatusUnauthorized:
+		return fmt.Errorf("unauthorized action, please setup authentication for this server")
+
+	default:
+		var err error
+		bytesOut, err := io.ReadAll(res.Body)
+		if err != nil {
+			return err
+		}
+
+		return fmt.Errorf("unexpected status code: %d, message: %q", res.StatusCode, string(bytesOut))
+	}
+	return nil
+}
+
 // GetFunctions lists all functions
 func (s *Client) GetFunctions(ctx context.Context, namespace string) ([]types.FunctionStatus, error) {
 	u := s.GatewayURL

--- a/client_test.go
+++ b/client_test.go
@@ -205,3 +205,254 @@ func TestSdk_DeleteFunction(t *testing.T) {
 		})
 	}
 }
+
+func TestSdk_GetNamespace(t *testing.T) {
+	nsName := "ns1"
+	tests := []struct {
+		name      string
+		namespace string
+		err       error
+		handler   func(rw http.ResponseWriter, req *http.Request)
+	}{
+		{
+			name:      "namespace not found",
+			namespace: nsName,
+			handler: func(rw http.ResponseWriter, req *http.Request) {
+				rw.WriteHeader(http.StatusNotFound)
+			},
+			err: fmt.Errorf("namespace %s not found", nsName),
+		},
+		{
+			name:      "client not authorized",
+			namespace: nsName,
+			handler: func(rw http.ResponseWriter, req *http.Request) {
+				rw.WriteHeader(http.StatusUnauthorized)
+			},
+			err: fmt.Errorf("unauthorized action, please setup authentication for this server"),
+		},
+		{
+			name:      "unknown error",
+			namespace: nsName,
+			handler: func(rw http.ResponseWriter, req *http.Request) {
+				http.Error(rw, string("unknown error"), http.StatusInternalServerError)
+			},
+			err: fmt.Errorf("unexpected status code: %d, message: %q", http.StatusInternalServerError, string("unknown error\n")),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := httptest.NewServer(http.HandlerFunc(test.handler))
+
+			sU, _ := url.Parse(s.URL)
+
+			client := NewClient(sU, nil, http.DefaultClient)
+			_, err := client.GetNamespace(context.Background(), test.namespace)
+
+			if !errors.Is(err, test.err) && err.Error() != test.err.Error() {
+				t.Fatalf("wanted %s, but got: %s", test.err, err)
+			}
+		})
+	}
+}
+
+func TestSdk_CreateNamespace(t *testing.T) {
+	nsName := "ns1"
+	tests := []struct {
+		name    string
+		req     types.FunctionNamespace
+		err     error
+		handler func(rw http.ResponseWriter, req *http.Request)
+	}{
+		{
+			name: "namespace created with no label and annotation",
+			req: types.FunctionNamespace{
+				Name: nsName,
+			},
+			handler: func(rw http.ResponseWriter, req *http.Request) {
+				rw.WriteHeader(http.StatusOK)
+			},
+		},
+		{
+			name: "namespace created with no label and annotation",
+			req: types.FunctionNamespace{
+				Name:        nsName,
+				Labels:      map[string]string{},
+				Annotations: map[string]string{},
+			},
+			handler: func(rw http.ResponseWriter, req *http.Request) {
+				rw.WriteHeader(http.StatusOK)
+			},
+		},
+		{
+			name: "client not authorized",
+			req: types.FunctionNamespace{
+				Name: nsName,
+			},
+			handler: func(rw http.ResponseWriter, req *http.Request) {
+				rw.WriteHeader(http.StatusUnauthorized)
+			},
+			err: fmt.Errorf("unauthorized action, please setup authentication for this server"),
+		},
+		{
+			name: "unknown error",
+			req: types.FunctionNamespace{
+				Name: nsName,
+			},
+			handler: func(rw http.ResponseWriter, req *http.Request) {
+				http.Error(rw, string("unknown error"), http.StatusInternalServerError)
+			},
+			err: fmt.Errorf("unexpected status code: %d, message: %q", http.StatusInternalServerError, string("unknown error\n")),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := httptest.NewServer(http.HandlerFunc(test.handler))
+
+			sU, _ := url.Parse(s.URL)
+
+			client := NewClient(sU, nil, http.DefaultClient)
+			_, err := client.CreateNamespace(context.Background(), test.req)
+
+			if !errors.Is(err, test.err) && err.Error() != test.err.Error() {
+				t.Fatalf("wanted %s, but got: %s", test.err, err)
+			}
+		})
+	}
+}
+
+func TestSdk_UpdateNamespace(t *testing.T) {
+	nsName := "ns1"
+	tests := []struct {
+		name    string
+		req     types.FunctionNamespace
+		err     error
+		handler func(rw http.ResponseWriter, req *http.Request)
+	}{
+		{
+			name: "namespace updated with no label and annotation",
+			req: types.FunctionNamespace{
+				Name: nsName,
+			},
+			handler: func(rw http.ResponseWriter, req *http.Request) {
+				rw.WriteHeader(http.StatusOK)
+			},
+		},
+		{
+			name: "namespace updated with no label and annotation",
+			req: types.FunctionNamespace{
+				Name:        nsName,
+				Labels:      map[string]string{},
+				Annotations: map[string]string{},
+			},
+			handler: func(rw http.ResponseWriter, req *http.Request) {
+				rw.WriteHeader(http.StatusOK)
+			},
+		},
+		{
+			name: "namespace not found",
+			req: types.FunctionNamespace{
+				Name:        nsName,
+				Labels:      map[string]string{},
+				Annotations: map[string]string{},
+			},
+			handler: func(rw http.ResponseWriter, req *http.Request) {
+				rw.WriteHeader(http.StatusNotFound)
+			},
+			err: fmt.Errorf("namespace %s not found", nsName),
+		},
+		{
+			name: "client not authorized",
+			req: types.FunctionNamespace{
+				Name: nsName,
+			},
+			handler: func(rw http.ResponseWriter, req *http.Request) {
+				rw.WriteHeader(http.StatusUnauthorized)
+			},
+			err: fmt.Errorf("unauthorized action, please setup authentication for this server"),
+		},
+		{
+			name: "unknown error",
+			req: types.FunctionNamespace{
+				Name: nsName,
+			},
+			handler: func(rw http.ResponseWriter, req *http.Request) {
+				http.Error(rw, string("unknown error"), http.StatusInternalServerError)
+			},
+			err: fmt.Errorf("unexpected status code: %d, message: %q", http.StatusInternalServerError, string("unknown error\n")),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := httptest.NewServer(http.HandlerFunc(test.handler))
+
+			sU, _ := url.Parse(s.URL)
+
+			client := NewClient(sU, nil, http.DefaultClient)
+			_, err := client.UpdateNamespace(context.Background(), test.req)
+
+			if !errors.Is(err, test.err) && err.Error() != test.err.Error() {
+				t.Fatalf("wanted %s, but got: %s", test.err, err)
+			}
+		})
+	}
+}
+
+func TestSdk_DeleteNamespace(t *testing.T) {
+	nsName := "ns1"
+	tests := []struct {
+		name      string
+		namespace string
+		err       error
+		handler   func(rw http.ResponseWriter, req *http.Request)
+	}{
+		{
+			name:      "namespace deleted",
+			namespace: nsName,
+			handler: func(rw http.ResponseWriter, req *http.Request) {
+				rw.WriteHeader(http.StatusOK)
+			},
+		},
+		{
+			name:      "namespace not found",
+			namespace: nsName,
+			handler: func(rw http.ResponseWriter, req *http.Request) {
+				rw.WriteHeader(http.StatusNotFound)
+			},
+			err: fmt.Errorf("namespace %s not found", nsName),
+		},
+		{
+			name:      "client not authorized",
+			namespace: nsName,
+			handler: func(rw http.ResponseWriter, req *http.Request) {
+				rw.WriteHeader(http.StatusUnauthorized)
+			},
+			err: fmt.Errorf("unauthorized action, please setup authentication for this server"),
+		},
+		{
+			name:      "unknown error",
+			namespace: nsName,
+			handler: func(rw http.ResponseWriter, req *http.Request) {
+				http.Error(rw, string("unknown error"), http.StatusInternalServerError)
+			},
+			err: fmt.Errorf("unexpected status code: %d, message: %q", http.StatusInternalServerError, string("unknown error\n")),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := httptest.NewServer(http.HandlerFunc(test.handler))
+
+			sU, _ := url.Parse(s.URL)
+
+			client := NewClient(sU, nil, http.DefaultClient)
+			err := client.DeleteNamespace(context.Background(), test.namespace)
+
+			if !errors.Is(err, test.err) && err.Error() != test.err.Error() {
+				t.Fatalf("wanted %s, but got: %s", test.err, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add [namespace management](https://docs.openfaas.com/reference/rest-api/#namespace-management) support in `go-sdk`


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change **this is required**
Closes #11 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Created a test code script and same has been tested against `faasd`

```
package main

import (
	"context"
	"fmt"
	"log"
	"net/http"
	"net/url"
	"os"

	"github.com/openfaas/faas-provider/types"
	"github.com/openfaas/go-sdk"
)

func main() {
	username := os.Getenv("OPENFAAS_USERNAME")
	password := os.Getenv("OPENFAAS_PASSWORD")

	gatewayURL, _ := url.Parse(os.Getenv("OPENFAAS_GATEWAY_URL"))
	auth := &sdk.BasicAuth{
		Username: username,
		Password: password,
	}
	nsName := "test-sdk-ns"

	client := sdk.NewClient(gatewayURL, auth, http.DefaultClient)

	// create namespace
	_, err := client.CreateNamespace(context.Background(), types.FunctionNamespace{
		Name: nsName,
		Labels: map[string]string{
			"purpose": "test",
		},
	})

	if err != nil {
		log.Fatalf("Namespace creation Failed: %s", err)
	}
	fmt.Printf("Namespace %s created!\n", nsName)

	// get namespace
	res, err := client.GetNamespace(context.Background(), nsName)

	if err != nil {
		log.Fatalf("Namespace get Failed: %s", err)
	}

	fmt.Printf("GetNamespace: %q\n", res)

	// update namespace
	_, err = client.UpdateNamespace(context.Background(), types.FunctionNamespace{
		Name: nsName,
		Labels: map[string]string{
			"purpose": "test",
			"demo":    "false",
		},
	})

	if err != nil {
		log.Fatalf("Namespace update Failed: %s", err)
	}

	res, err = client.GetNamespace(context.Background(), nsName)

	if err != nil {
		log.Fatalf("Namespace get Failed: %s", err)
	}

	demo, found := res.Labels["demo"]

	if !found || demo != "false" {
		log.Fatalf("Namespace update Failed: %s", err)
	}
	fmt.Printf("Updated Namespace: %q\n", res)

	// delete namespace
	err = client.DeleteNamespace(context.Background(), nsName)

	if err != nil {
		log.Fatalf("Namespace %s delete Failed: %s", nsName, err)
	}
	fmt.Printf("Namespace %s deleted!\n", nsName)

	// get namespaces
	namespaces, err := client.GetNamespaces(context.Background())
	fmt.Printf("Namespaces: %q\n", namespaces)
}

```
2. Github action part was tested with the help of [act](https://github.com/nektos/act) cli

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
 