### PR TITLE
Use function name as cache key for function access tokens 

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,9 +199,12 @@ client := sdk.NewClientWithOpts(gatewayURL, http.DefaultClient, sdk.WithFunction
 Optionally a `TokenCache` can be configured to cache function access tokens and prevent the client from having to do a token exchange each time a function is invoked.
 
 ```go
+ctx, cancel := context.WithCancel(context.Background())
+defer cancel()
+
 fnTokenCache := sdk.NewMemoryTokenCache()
 // Start garbage collection to remove expired tokens from the cache.
-go fnTokenCache.StartGC(context.Background(), time.Second*10)
+go fnTokenCache.StartGC(ctx, time.Second*10)
 
 client := sdk.NewClientWithOpts(
     gatewayUrl,

--- a/functions.go
+++ b/functions.go
@@ -1,7 +1,6 @@
 package sdk
 
 import (
-	"crypto/sha256"
 	"fmt"
 	"net/http"
 )
@@ -36,8 +35,7 @@ func (c *Client) InvokeFunction(name, namespace string, async bool, auth bool, r
 		if c.fnTokenCache != nil {
 			// Function access tokens are cached as long as the token is valid
 			// to prevent having to do a token exchange each time the function is invoked.
-			cacheKey := getFunctionTokenCacheKey(idToken, fmt.Sprintf("%s.%s", name, namespace))
-
+			cacheKey := fmt.Sprintf("%s.%s", name, namespace)
 			token, ok := c.fnTokenCache.Get(cacheKey)
 			if !ok {
 				token, err = ExchangeIDToken(tokenURL, idToken, WithScope(scope), WithAudience(audience))
@@ -62,18 +60,4 @@ func (c *Client) InvokeFunction(name, namespace string, async bool, auth bool, r
 	}
 
 	return c.do(req)
-}
-
-// getFunctionTokenCacheKey computes a cache key for caching a function access token based
-// on the original id token that is exchanged for the function access token and the function
-// name e.g. figlet.openfaas-fn.
-// The original token is included in the hash to avoid cache hits for a function when the
-// source token changes.
-func getFunctionTokenCacheKey(idToken string, serviceName string) string {
-	hash := sha256.New()
-	hash.Write([]byte(idToken))
-	hash.Write([]byte(serviceName))
-
-	sum := hash.Sum(nil)
-	return fmt.Sprintf("%x", sum)
 }


### PR DESCRIPTION
## Description

Remove the source token as part of the cache key.

By using the source token as part of the cache key the cache would be invalidated when the original access token had expired which is confusing for users and leads to higher load on the token exchange endpoint if short lived tokens are used.

Using the source token as part if the cache key is not required since an authenticated clients should not be shared between different users.

## Motivation and context

Simplify the client and reduce the number of token exchanges required when using short lived tokens.

## How has this been tested

This has been tested E2E in multiple OpenFaaS components (CLI, pro-connector-sdk) 