### PR TITLE
Add default user agent to sdk requests

### DIFF
--- a/client.go
+++ b/client.go
@@ -38,8 +38,13 @@ type Client struct {
 	fnTokenCache TokenCache
 }
 
-// Wrap http request Do function to support debug capabilities
+// Wrap http request Do function to add default headers and support debug capabilities
 func (s *Client) do(req *http.Request) (*http.Response, error) {
+	// Add default user-agent header
+	if len(req.Header.Get("User-Agent")) == 0 {
+		req.Header.Set("User-Agent", "openfaas-go-sdk")
+	}
+
 	if os.Getenv("FAAS_DEBUG") == "1" {
 		dump, err := dumpRequest(req)
 		if err != nil {

--- a/client_credentials_auth.go
+++ b/client_credentials_auth.go
@@ -95,6 +95,7 @@ func obtainClientCredentialsToken(clientID, clientSecret, tokenURL, scope, grant
 		return nil, err
 	}
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", "openfaas-go-sdk")
 
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/exchange.go
+++ b/exchange.go
@@ -43,6 +43,7 @@ func ExchangeIDToken(tokenURL, rawIDToken string, options ...ExchangeOption) (*T
 	}
 
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", "openfaas-go-sdk")
 
 	if os.Getenv("FAAS_DEBUG") == "1" {
 		dump, err := dumpRequest(req)


### PR DESCRIPTION
## Description

Add the `User-Agent` header with a default value of `openfaas-go-sdk` in requests made by the sdk.

## Motivation and context

Closes #31 