### PR TITLE
Support request debug logging in the builder package

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/alexellis/hmac/v2"
+	"github.com/openfaas/go-sdk/internal/httpclient"
 )
 
 const BuilderConfigFileName = "com.openfaas.docker.config"
@@ -80,6 +81,8 @@ func WithHmacAuth(secret string) BuilderOption {
 
 // NewFunctionBuilder create a new builder for building OpenFaaS functions using the Function Builder API.
 func NewFunctionBuilder(url *url.URL, client *http.Client, options ...BuilderOption) *FunctionBuilder {
+	client = httpclient.WithFaasTransport(client)
+
 	b := &FunctionBuilder{
 		URL: url,
 

--- a/client_test.go
+++ b/client_test.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strings"
 	"testing"
 	"time"
 
@@ -781,106 +779,6 @@ func TestSdk_DeleteSecret(t *testing.T) {
 
 			if !errors.Is(err, test.err) && err.Error() != test.err.Error() {
 				t.Fatalf("wanted %s, but got: %s", test.err, err)
-			}
-		})
-	}
-}
-
-func Test_dumpRequest(t *testing.T) {
-	tests := []struct {
-		name string
-		req  *http.Request
-		want string
-	}{
-		{
-			name: "request without body",
-			req: &http.Request{
-				Method: http.MethodPost,
-				URL: &url.URL{
-					Scheme: "https",
-					Host:   "gw.example.com",
-					Path:   "/function/env.openfaas-fn",
-				},
-			},
-			want: "POST https://gw.example.com/function/env.openfaas-fn\n",
-		},
-		{
-			name: "request with headers",
-			req: &http.Request{
-				Method: http.MethodPost,
-				URL: &url.URL{
-					Scheme: "https",
-					Host:   "gw.example.com",
-					Path:   "/function/env.openfaas-fn",
-				},
-				Header: http.Header{
-					"Content-Type": []string{"text/plain"},
-					"User-Agent":   []string{"openfaas-go-sdk"},
-				},
-			},
-			want: "POST https://gw.example.com/function/env.openfaas-fn\n" +
-				"Content-Type: [text/plain]\n" +
-				"User-Agent: [openfaas-go-sdk]\n",
-		},
-		{
-			name: "request with body",
-			req: &http.Request{
-				Method: http.MethodPost,
-				URL: &url.URL{
-					Scheme: "https",
-					Host:   "gw.example.com",
-					Path:   "/function/env.openfaas-fn",
-				},
-				Header: http.Header{},
-				Body:   io.NopCloser(strings.NewReader("Hello OpenFaaS!!")),
-			},
-			want: "POST https://gw.example.com/function/env.openfaas-fn\n" +
-				"Hello OpenFaaS!!\n",
-		},
-		{
-			name: "request with bearer auth",
-			req: &http.Request{
-				Method: http.MethodPost,
-				URL: &url.URL{
-					Scheme: "https",
-					Host:   "gw.example.com",
-					Path:   "/function/env.openfaas-fn",
-				},
-				Header: http.Header{
-					"Authorization": []string{"Bearer secret openfaas-token"},
-				},
-			},
-			want: "POST https://gw.example.com/function/env.openfaas-fn\n" +
-				"Authorization: Bearer [REDACTED]\n",
-		},
-		{
-			name: "request with basic auth",
-			req: &http.Request{
-				Method: http.MethodPost,
-				URL: &url.URL{
-					Scheme: "https",
-					Host:   "gw.example.com",
-					Path:   "/function/env.openfaas-fn",
-				},
-				Header: http.Header{
-					"Authorization": []string{"Basic username:password"},
-				},
-			},
-			want: "POST https://gw.example.com/function/env.openfaas-fn\n" +
-				"Authorization: Basic [REDACTED]\n",
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			got, err := dumpRequest(test.req)
-
-			if err != nil {
-				t.Errorf("want %s, but got error: %s", test.want, err)
-			}
-
-			if test.want != got {
-				t.Errorf("want %s, but got: %s", test.want, got)
 			}
 		})
 	}

--- a/exchange.go
+++ b/exchange.go
@@ -8,6 +8,8 @@ import (
 	"net/url"
 	"os"
 	"strings"
+
+	"github.com/openfaas/go-sdk/internal/httpclient"
 )
 
 // Exchange an OIDC ID Token from an IdP for OpenFaaS token
@@ -46,7 +48,7 @@ func ExchangeIDToken(tokenURL, rawIDToken string, options ...ExchangeOption) (*T
 	req.Header.Set("User-Agent", "openfaas-go-sdk")
 
 	if os.Getenv("FAAS_DEBUG") == "1" {
-		dump, err := dumpRequest(req)
+		dump, err := httpclient.DumpRequest(req)
 		if err != nil {
 			return nil, err
 		}

--- a/functions.go
+++ b/functions.go
@@ -59,5 +59,5 @@ func (c *Client) InvokeFunction(name, namespace string, async bool, auth bool, r
 		req.Header.Add("Authorization", "Bearer "+bearer)
 	}
 
-	return c.do(req)
+	return c.client.Do(req)
 }

--- a/internal/httpclient/transport.go
+++ b/internal/httpclient/transport.go
@@ -1,0 +1,125 @@
+package httpclient
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+)
+
+// FaasTransport is an http.RoundTripper that adds default headers and request logging capabilities.
+// Requests will be logged to the console if the FAAS_DEBUG environment variable is set to 1.
+type FaasTransport struct {
+	// Transport is the underlying HTTP transport to use when making requests.
+	// It will default to http.DefaultTransport if nil.
+	Transport http.RoundTripper
+}
+
+func (t *FaasTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Add default user-agent header
+	if len(req.Header.Get("User-Agent")) == 0 {
+		req.Header.Set("User-Agent", "openfaas-go-sdk")
+	}
+
+	// If the FAAS_DEBUG environment variable is set to 1, dump the request to the console
+	if os.Getenv("FAAS_DEBUG") == "1" {
+		dump, err := DumpRequest(req)
+		if err != nil {
+			return nil, err
+		}
+
+		fmt.Println(dump)
+	}
+
+	// Call the underlying transport
+	return t.transport().RoundTrip(req)
+}
+
+func (t *FaasTransport) transport() http.RoundTripper {
+	if t.Transport != nil {
+		return t.Transport
+	}
+	return http.DefaultTransport
+}
+
+// WithFaasTransport clones the http.Client and wraps the Transport with a FaasTransport.
+// If the provided client is nil, the http.DefaultClient is used.
+func WithFaasTransport(client *http.Client) *http.Client {
+	if client == nil {
+		return &http.Client{
+			Transport: &FaasTransport{},
+		}
+	}
+
+	decoratedClient := &http.Client{}
+	decoratedClient.Transport = &FaasTransport{
+		Transport: client.Transport,
+	}
+	decoratedClient.CheckRedirect = client.CheckRedirect
+	decoratedClient.Jar = client.Jar
+	decoratedClient.Timeout = client.Timeout
+
+	return decoratedClient
+}
+
+func DumpRequest(req *http.Request) (string, error) {
+	var sb strings.Builder
+
+	// Get all header keys and sort them
+	keys := make([]string, 0, len(req.Header))
+	for k := range req.Header {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	sb.WriteString(fmt.Sprintf("%s %s\n", req.Method, req.URL.String()))
+	for _, k := range keys {
+		v := req.Header[k]
+		if k == "Authorization" {
+			auth := "[REDACTED]"
+			if len(v) == 0 {
+				auth = "[NOT_SET]"
+			} else {
+				l, _, ok := strings.Cut(v[0], " ")
+				if ok && (l == "Basic" || l == "Bearer") {
+					auth = l + " [REDACTED]"
+				}
+			}
+			sb.WriteString(fmt.Sprintf("%s: %s\n", k, auth))
+
+		} else {
+			sb.WriteString(fmt.Sprintf("%s: %s\n", k, v))
+		}
+	}
+
+	contentType := req.Header.Get("Content-Type")
+	if req.Body != nil && isPrintableContentType(contentType) {
+		r := io.NopCloser(req.Body)
+		buf := new(strings.Builder)
+		_, err := io.Copy(buf, r)
+		if err != nil {
+			return "", err
+		}
+		bodyDebug := buf.String()
+		if len(bodyDebug) > 0 {
+			sb.WriteString(fmt.Sprintf("%s\n", bodyDebug))
+
+		}
+	}
+
+	return sb.String(), nil
+}
+
+func isPrintableContentType(contentType string) bool {
+	contentType = strings.ToLower(contentType)
+
+	if strings.Contains(contentType, "application/json") ||
+		strings.Contains(contentType, "text/plain") ||
+		strings.Contains(contentType, "application/x-www-form-urlencoded") {
+		return true
+	}
+
+	return false
+}

--- a/internal/httpclient/transport_test.go
+++ b/internal/httpclient/transport_test.go
@@ -1,0 +1,112 @@
+package httpclient
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func Test_dumpRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *http.Request
+		want string
+	}{
+		{
+			name: "request without body",
+			req: &http.Request{
+				Method: http.MethodPost,
+				URL: &url.URL{
+					Scheme: "https",
+					Host:   "gw.example.com",
+					Path:   "/function/env.openfaas-fn",
+				},
+			},
+			want: "POST https://gw.example.com/function/env.openfaas-fn\n",
+		},
+		{
+			name: "request with headers",
+			req: &http.Request{
+				Method: http.MethodPost,
+				URL: &url.URL{
+					Scheme: "https",
+					Host:   "gw.example.com",
+					Path:   "/function/env.openfaas-fn",
+				},
+				Header: http.Header{
+					"Content-Type": []string{"text/plain"},
+					"User-Agent":   []string{"openfaas-go-sdk"},
+				},
+			},
+			want: "POST https://gw.example.com/function/env.openfaas-fn\n" +
+				"Content-Type: [text/plain]\n" +
+				"User-Agent: [openfaas-go-sdk]\n",
+		},
+		{
+			name: "request with body",
+			req: &http.Request{
+				Method: http.MethodPost,
+				URL: &url.URL{
+					Scheme: "https",
+					Host:   "gw.example.com",
+					Path:   "/function/env.openfaas-fn",
+				},
+				Header: http.Header{
+					"Content-Type": []string{"text/plain"},
+				},
+				Body: io.NopCloser(strings.NewReader("Hello OpenFaaS!!")),
+			},
+			want: "POST https://gw.example.com/function/env.openfaas-fn\n" +
+				"Content-Type: [text/plain]\n" +
+				"Hello OpenFaaS!!\n",
+		},
+		{
+			name: "request with bearer auth",
+			req: &http.Request{
+				Method: http.MethodPost,
+				URL: &url.URL{
+					Scheme: "https",
+					Host:   "gw.example.com",
+					Path:   "/function/env.openfaas-fn",
+				},
+				Header: http.Header{
+					"Authorization": []string{"Bearer secret openfaas-token"},
+				},
+			},
+			want: "POST https://gw.example.com/function/env.openfaas-fn\n" +
+				"Authorization: Bearer [REDACTED]\n",
+		},
+		{
+			name: "request with basic auth",
+			req: &http.Request{
+				Method: http.MethodPost,
+				URL: &url.URL{
+					Scheme: "https",
+					Host:   "gw.example.com",
+					Path:   "/function/env.openfaas-fn",
+				},
+				Header: http.Header{
+					"Authorization": []string{"Basic username:password"},
+				},
+			},
+			want: "POST https://gw.example.com/function/env.openfaas-fn\n" +
+				"Authorization: Basic [REDACTED]\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := DumpRequest(test.req)
+
+			if err != nil {
+				t.Errorf("want %s, but got error: %s", test.want, err)
+			}
+
+			if test.want != got {
+				t.Errorf("want %s, but got: %s", test.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Support setting `FAAS_DEBUG=1` for request made to the Function Builder API using the go-sdk.

The request body is only logged if the Content-Type is printable (e.g. application/json or text/plain) to prevent payloads that are not human readable, like the build context tar, from getting logged out.

## How has this been tested

Unit test have been updated and this change has been tested by using this version of the go-sdk with the faas-cli.

Verified requests are printed to the console correctly when the `FAAS_DEBUG=1` env variable is set.