### PR TITLE
Increase IdleConnTimeout from 120ms to 5s

### DIFF
--- a/stack/stack.go
+++ b/stack/stack.go
@@ -144,11 +144,8 @@ func makeHTTPClient(timeout *time.Duration) http.Client {
 				Proxy: http.ProxyFromEnvironment,
 				DialContext: (&net.Dialer{
 					Timeout: *timeout,
-					// KeepAlive: 0,
 				}).DialContext,
-				// MaxIdleConns:          1,
-				// DisableKeepAlives:     true,
-				IdleConnTimeout:       120 * time.Millisecond,
+				IdleConnTimeout:       5 * time.Second,
 				ExpectContinueTimeout: 1500 * time.Millisecond,
 			},
 		}


### PR DESCRIPTION
## Description

Increase the `IdleConnTimeout` in `makeHTTPClient` from 120ms to 5s. The previous value was too aggressive and could cause connections to be closed before they could be reused from the connection pool.

Also removes commented-out transport configuration (`KeepAlive`, `MaxIdleConns`, `DisableKeepAlives`) that was left behind.

## Motivation and Context

Whilst not as important here since a new HTTP client is created for every call to fetchYAML, this is being updated for consistency across components.