### PR TITLE
Add sentinel errors for HTTP status code handling

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -16,6 +17,13 @@ import (
 	"github.com/openfaas/faas-provider/logs"
 	"github.com/openfaas/faas-provider/types"
 	"github.com/openfaas/go-sdk/internal/httpclient"
+)
+
+var (
+	ErrNotFound         = errors.New("not found")
+	ErrUnauthorized     = errors.New("unauthorized")
+	ErrForbidden        = errors.New("forbidden")
+	ErrUnexpectedStatus = errors.New("unexpected response status")
 )
 
 // Client is used to manage OpenFaaS and invoke functions
@@ -127,24 +135,37 @@ func (s *Client) GetNamespaces(ctx context.Context) ([]string, error) {
 		defer res.Body.Close()
 	}
 
-	bytesOut, err := io.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return namespaces, err
 	}
 
-	if res.StatusCode == http.StatusUnauthorized {
-		return namespaces, fmt.Errorf("check authorization, status code: %d", res.StatusCode)
-	}
+	switch res.StatusCode {
+	case http.StatusOK:
+		if len(body) == 0 {
+			return namespaces, nil
+		}
 
-	if len(bytesOut) == 0 {
+		if err := json.Unmarshal(body, &namespaces); err != nil {
+			return namespaces, fmt.Errorf("unable to unmarshal value: %q, error: %w", string(body), err)
+		}
 		return namespaces, nil
-	}
 
-	if err := json.Unmarshal(bytesOut, &namespaces); err != nil {
-		return namespaces, fmt.Errorf("unable to marshal to JSON: %s, error: %w", string(bytesOut), err)
-	}
+	case http.StatusUnauthorized:
+		if len(body) > 0 {
+			return namespaces, fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return namespaces, ErrUnauthorized
 
-	return namespaces, err
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return namespaces, fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return namespaces, ErrForbidden
+
+	default:
+		return namespaces, fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
+	}
 }
 
 // GetNamespaces get openfaas namespaces
@@ -183,13 +204,22 @@ func (s *Client) GetNamespace(ctx context.Context, namespace string) (types.Func
 		return fnNamespace, err
 
 	case http.StatusNotFound:
-		return types.FunctionNamespace{}, fmt.Errorf("namespace %s not found", namespace)
+		return types.FunctionNamespace{}, fmt.Errorf("%w: namespace %s", ErrNotFound, namespace)
 
 	case http.StatusUnauthorized:
-		return types.FunctionNamespace{}, fmt.Errorf("unauthorized action, please setup authentication for this server")
+		if len(body) > 0 {
+			return types.FunctionNamespace{}, fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return types.FunctionNamespace{}, ErrUnauthorized
+
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return types.FunctionNamespace{}, fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return types.FunctionNamespace{}, ErrForbidden
 
 	default:
-		return types.FunctionNamespace{}, fmt.Errorf("unexpected status code: %d, message: %q", res.StatusCode, string(body))
+		return types.FunctionNamespace{}, fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
 	}
 }
 
@@ -246,10 +276,19 @@ func (s *Client) CreateNamespace(ctx context.Context, spec types.FunctionNamespa
 		return res.StatusCode, nil
 
 	case http.StatusUnauthorized:
-		return res.StatusCode, fmt.Errorf("unauthorized action, please setup authentication for this server")
+		if len(body) > 0 {
+			return res.StatusCode, fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return res.StatusCode, ErrUnauthorized
+
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return res.StatusCode, fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return res.StatusCode, ErrForbidden
 
 	default:
-		return res.StatusCode, fmt.Errorf("unexpected status code: %d, message: %q", res.StatusCode, string(body))
+		return res.StatusCode, fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
 	}
 }
 
@@ -306,13 +345,22 @@ func (s *Client) UpdateNamespace(ctx context.Context, spec types.FunctionNamespa
 		return res.StatusCode, nil
 
 	case http.StatusNotFound:
-		return res.StatusCode, fmt.Errorf("namespace %s not found", spec.Name)
+		return res.StatusCode, fmt.Errorf("%w: namespace %s", ErrNotFound, spec.Name)
 
 	case http.StatusUnauthorized:
-		return res.StatusCode, fmt.Errorf("unauthorized action, please setup authentication for this server")
+		if len(body) > 0 {
+			return res.StatusCode, fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return res.StatusCode, ErrUnauthorized
+
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return res.StatusCode, fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return res.StatusCode, ErrForbidden
 
 	default:
-		return res.StatusCode, fmt.Errorf("unexpected status code: %d, message: %q", res.StatusCode, string(body))
+		return res.StatusCode, fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
 	}
 }
 
@@ -355,24 +403,29 @@ func (s *Client) DeleteNamespace(ctx context.Context, namespace string) error {
 		defer res.Body.Close()
 	}
 
+	body, _ := io.ReadAll(res.Body)
+
 	switch res.StatusCode {
 	case http.StatusAccepted, http.StatusOK, http.StatusCreated:
 		break
 
 	case http.StatusNotFound:
-		return fmt.Errorf("namespace %s not found", namespace)
+		return fmt.Errorf("%w: namespace %s", ErrNotFound, namespace)
 
 	case http.StatusUnauthorized:
-		return fmt.Errorf("unauthorized action, please setup authentication for this server")
+		if len(body) > 0 {
+			return fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return ErrUnauthorized
+
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return ErrForbidden
 
 	default:
-		var err error
-		bytesOut, err := io.ReadAll(res.Body)
-		if err != nil {
-			return err
-		}
-
-		return fmt.Errorf("unexpected status code: %d, message: %q", res.StatusCode, string(bytesOut))
+		return fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
 	}
 	return nil
 }
@@ -410,13 +463,30 @@ func (s *Client) GetFunctions(ctx context.Context, namespace string) ([]types.Fu
 
 	body, _ := io.ReadAll(res.Body)
 
-	functions := []types.FunctionStatus{}
-	if err := json.Unmarshal(body, &functions); err != nil {
-		return []types.FunctionStatus{},
-			fmt.Errorf("unable to unmarshal value: %q, error: %w", string(body), err)
-	}
+	switch res.StatusCode {
+	case http.StatusOK:
+		functions := []types.FunctionStatus{}
+		if err := json.Unmarshal(body, &functions); err != nil {
+			return []types.FunctionStatus{},
+				fmt.Errorf("unable to unmarshal value: %q, error: %w", string(body), err)
+		}
+		return functions, nil
 
-	return functions, nil
+	case http.StatusUnauthorized:
+		if len(body) > 0 {
+			return []types.FunctionStatus{}, fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return []types.FunctionStatus{}, ErrUnauthorized
+
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return []types.FunctionStatus{}, fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return []types.FunctionStatus{}, ErrForbidden
+
+	default:
+		return []types.FunctionStatus{}, fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
+	}
 }
 
 func (s *Client) GetInfo(ctx context.Context) (SystemInfo, error) {
@@ -445,13 +515,30 @@ func (s *Client) GetInfo(ctx context.Context) (SystemInfo, error) {
 
 	body, _ := io.ReadAll(res.Body)
 
-	info := SystemInfo{}
-	if err := json.Unmarshal(body, &info); err != nil {
-		return SystemInfo{},
-			fmt.Errorf("unable to unmarshal value: %q, error: %w", string(body), err)
-	}
+	switch res.StatusCode {
+	case http.StatusOK:
+		info := SystemInfo{}
+		if err := json.Unmarshal(body, &info); err != nil {
+			return SystemInfo{},
+				fmt.Errorf("unable to unmarshal value: %q, error: %w", string(body), err)
+		}
+		return info, nil
 
-	return info, nil
+	case http.StatusUnauthorized:
+		if len(body) > 0 {
+			return SystemInfo{}, fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return SystemInfo{}, ErrUnauthorized
+
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return SystemInfo{}, fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return SystemInfo{}, ErrForbidden
+
+	default:
+		return SystemInfo{}, fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
+	}
 }
 
 // GetFunction gives a richer payload than GetFunctions, but for a specific function
@@ -487,13 +574,33 @@ func (s *Client) GetFunction(ctx context.Context, name, namespace string) (types
 
 	body, _ := io.ReadAll(res.Body)
 
-	function := types.FunctionStatus{}
-	if err := json.Unmarshal(body, &function); err != nil {
-		return types.FunctionStatus{},
-			fmt.Errorf("unable to unmarshal value: %q, error: %w", string(body), err)
-	}
+	switch res.StatusCode {
+	case http.StatusOK:
+		function := types.FunctionStatus{}
+		if err := json.Unmarshal(body, &function); err != nil {
+			return types.FunctionStatus{},
+				fmt.Errorf("unable to unmarshal value: %q, error: %w", string(body), err)
+		}
+		return function, nil
 
-	return function, nil
+	case http.StatusNotFound:
+		return types.FunctionStatus{}, fmt.Errorf("%w: function %s", ErrNotFound, name)
+
+	case http.StatusUnauthorized:
+		if len(body) > 0 {
+			return types.FunctionStatus{}, fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return types.FunctionStatus{}, ErrUnauthorized
+
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return types.FunctionStatus{}, fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return types.FunctionStatus{}, ErrForbidden
+
+	default:
+		return types.FunctionStatus{}, fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
+	}
 }
 
 func (s *Client) Deploy(ctx context.Context, spec types.FunctionDeployment) (int, error) {
@@ -545,10 +652,19 @@ func (s *Client) deploy(ctx context.Context, method string, spec types.FunctionD
 		return res.StatusCode, nil
 
 	case http.StatusUnauthorized:
-		return res.StatusCode, fmt.Errorf("unauthorized action, please setup authentication for this server")
+		if len(body) > 0 {
+			return res.StatusCode, fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return res.StatusCode, ErrUnauthorized
+
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return res.StatusCode, fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return res.StatusCode, ErrForbidden
 
 	default:
-		return res.StatusCode, fmt.Errorf("unexpected status code: %d, message: %q", res.StatusCode, string(body))
+		return res.StatusCode, fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
 	}
 }
 
@@ -590,24 +706,29 @@ func (s *Client) ScaleFunction(ctx context.Context, functionName, namespace stri
 		defer res.Body.Close()
 	}
 
+	body, _ := io.ReadAll(res.Body)
+
 	switch res.StatusCode {
 	case http.StatusAccepted, http.StatusOK, http.StatusCreated:
 		break
 
 	case http.StatusNotFound:
-		return fmt.Errorf("function %s not found", functionName)
+		return fmt.Errorf("%w: function %s", ErrNotFound, functionName)
 
 	case http.StatusUnauthorized:
-		return fmt.Errorf("unauthorized action, please setup authentication for this server")
+		if len(body) > 0 {
+			return fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return ErrUnauthorized
+
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return ErrForbidden
 
 	default:
-		var err error
-		bytesOut, err := io.ReadAll(res.Body)
-		if err != nil {
-			return err
-		}
-
-		return fmt.Errorf("server returned unexpected status code %d, message: %q", res.StatusCode, string(bytesOut))
+		return fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
 	}
 	return nil
 }
@@ -649,24 +770,29 @@ func (s *Client) DeleteFunction(ctx context.Context, functionName, namespace str
 		defer res.Body.Close()
 	}
 
+	body, _ := io.ReadAll(res.Body)
+
 	switch res.StatusCode {
 	case http.StatusAccepted, http.StatusOK, http.StatusCreated:
 		break
 
 	case http.StatusNotFound:
-		return fmt.Errorf("function %s not found", functionName)
+		return fmt.Errorf("%w: function %s", ErrNotFound, functionName)
 
 	case http.StatusUnauthorized:
-		return fmt.Errorf("unauthorized action, please setup authentication for this server")
+		if len(body) > 0 {
+			return fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return ErrUnauthorized
+
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return ErrForbidden
 
 	default:
-		var err error
-		bytesOut, err := io.ReadAll(res.Body)
-		if err != nil {
-			return err
-		}
-
-		return fmt.Errorf("server returned unexpected status code %d, message: %q", res.StatusCode, string(bytesOut))
+		return fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
 	}
 	return nil
 }
@@ -704,13 +830,30 @@ func (s *Client) GetSecrets(ctx context.Context, namespace string) ([]types.Secr
 
 	body, _ := io.ReadAll(res.Body)
 
-	secrets := []types.Secret{}
-	if err := json.Unmarshal(body, &secrets); err != nil {
-		return []types.Secret{},
-			fmt.Errorf("unable to unmarshal value: %q, error: %w", string(body), err)
-	}
+	switch res.StatusCode {
+	case http.StatusOK:
+		secrets := []types.Secret{}
+		if err := json.Unmarshal(body, &secrets); err != nil {
+			return []types.Secret{},
+				fmt.Errorf("unable to unmarshal value: %q, error: %w", string(body), err)
+		}
+		return secrets, nil
 
-	return secrets, nil
+	case http.StatusUnauthorized:
+		if len(body) > 0 {
+			return []types.Secret{}, fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return []types.Secret{}, ErrUnauthorized
+
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return []types.Secret{}, fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return []types.Secret{}, ErrForbidden
+
+	default:
+		return []types.Secret{}, fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
+	}
 }
 
 // CreateSecret creates a secret
@@ -754,10 +897,19 @@ func (s *Client) CreateSecret(ctx context.Context, spec types.Secret) (int, erro
 		return res.StatusCode, nil
 
 	case http.StatusUnauthorized:
-		return res.StatusCode, fmt.Errorf("unauthorized action, please setup authentication for this server")
+		if len(body) > 0 {
+			return res.StatusCode, fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return res.StatusCode, ErrUnauthorized
+
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return res.StatusCode, fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return res.StatusCode, ErrForbidden
 
 	default:
-		return res.StatusCode, fmt.Errorf("unexpected status code: %d, message: %q", res.StatusCode, string(body))
+		return res.StatusCode, fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
 	}
 }
 
@@ -802,13 +954,22 @@ func (s *Client) UpdateSecret(ctx context.Context, spec types.Secret) (int, erro
 		return res.StatusCode, nil
 
 	case http.StatusNotFound:
-		return res.StatusCode, fmt.Errorf("secret %s not found", spec.Name)
+		return res.StatusCode, fmt.Errorf("%w: secret %s", ErrNotFound, spec.Name)
 
 	case http.StatusUnauthorized:
-		return res.StatusCode, fmt.Errorf("unauthorized action, please setup authentication for this server")
+		if len(body) > 0 {
+			return res.StatusCode, fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return res.StatusCode, ErrUnauthorized
+
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return res.StatusCode, fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return res.StatusCode, ErrForbidden
 
 	default:
-		return res.StatusCode, fmt.Errorf("unexpected status code: %d, message: %q", res.StatusCode, string(body))
+		return res.StatusCode, fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
 	}
 }
 
@@ -849,24 +1010,29 @@ func (s *Client) DeleteSecret(ctx context.Context, secretName, namespace string)
 		defer res.Body.Close()
 	}
 
+	body, _ := io.ReadAll(res.Body)
+
 	switch res.StatusCode {
 	case http.StatusAccepted, http.StatusOK, http.StatusCreated:
 		break
 
 	case http.StatusNotFound:
-		return fmt.Errorf("secret %s not found", secretName)
+		return fmt.Errorf("%w: secret %s", ErrNotFound, secretName)
 
 	case http.StatusUnauthorized:
-		return fmt.Errorf("unauthorized action, please setup authentication for this server")
+		if len(body) > 0 {
+			return fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return ErrUnauthorized
+
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return ErrForbidden
 
 	default:
-		var err error
-		bytesOut, err := io.ReadAll(res.Body)
-		if err != nil {
-			return err
-		}
-
-		return fmt.Errorf("server returned unexpected status code %d, message: %q", res.StatusCode, string(bytesOut))
+		return fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
 	}
 	return nil
 }
@@ -949,16 +1115,28 @@ func (s *Client) GetLogs(ctx context.Context, functionName, namespace string, fo
 		}()
 
 	case http.StatusNotFound:
-		return nil, fmt.Errorf("function: %s not found", functionName)
+		return nil, fmt.Errorf("%w: function %s", ErrNotFound, functionName)
 
 	case http.StatusUnauthorized:
-		return nil, fmt.Errorf("unauthorized action, please setup authentication for this server")
+		bytesOut, err := io.ReadAll(res.Body)
+		if err == nil && len(bytesOut) > 0 {
+			return nil, fmt.Errorf("%w: %s", ErrUnauthorized, string(bytesOut))
+		}
+		return nil, ErrUnauthorized
+
+	case http.StatusForbidden:
+		bytesOut, err := io.ReadAll(res.Body)
+		if err == nil && len(bytesOut) > 0 {
+			return nil, fmt.Errorf("%w: %s", ErrForbidden, string(bytesOut))
+		}
+		return nil, ErrForbidden
 
 	default:
 		bytesOut, err := io.ReadAll(res.Body)
 		if err == nil {
-			return nil, fmt.Errorf("unexpected status code: %d, message: %q", res.StatusCode, string(bytesOut))
+			return nil, fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(bytesOut))
 		}
+		return nil, fmt.Errorf("%w: status code %d", ErrUnexpectedStatus, res.StatusCode)
 	}
 	return logStream, nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -207,9 +207,16 @@ func TestSdk_DeployFunction(t *testing.T) {
 			handler: func(rw http.ResponseWriter, req *http.Request) {
 				rw.WriteHeader(http.StatusUnauthorized)
 			},
-			err: fmt.Errorf(
-				"unauthorized action, please setup authentication for this server",
-			),
+			err: ErrUnauthorized,
+		},
+		{
+			name:         "client forbidden",
+			functionName: funcName,
+			namespace:    nsName,
+			handler: func(rw http.ResponseWriter, req *http.Request) {
+				rw.WriteHeader(http.StatusForbidden)
+			},
+			err: ErrForbidden,
 		},
 		{
 			name:         "unknown error",
@@ -218,11 +225,7 @@ func TestSdk_DeployFunction(t *testing.T) {
 			handler: func(rw http.ResponseWriter, req *http.Request) {
 				http.Error(rw, "unknown error", http.StatusInternalServerError)
 			},
-			err: fmt.Errorf(
-				"unexpected status code: %d, message: %q",
-				http.StatusInternalServerError,
-				"unknown error\n",
-			),
+			err: ErrUnexpectedStatus,
 		},
 	}
 
@@ -240,7 +243,7 @@ func TestSdk_DeployFunction(t *testing.T) {
 				Namespace: nsName,
 			})
 
-			if !errors.Is(err, test.err) && err.Error() != test.err.Error() {
+			if !errors.Is(err, test.err) {
 				t.Fatalf("wanted %s, but got: %s", test.err, err)
 			}
 		})
@@ -272,7 +275,7 @@ func TestSdk_DeleteFunction(t *testing.T) {
 			handler: func(rw http.ResponseWriter, req *http.Request) {
 				rw.WriteHeader(http.StatusNotFound)
 			},
-			err: fmt.Errorf("function %s not found", funcName),
+			err: ErrNotFound,
 		},
 		{
 			name:         "client not authorized",
@@ -281,9 +284,16 @@ func TestSdk_DeleteFunction(t *testing.T) {
 			handler: func(rw http.ResponseWriter, req *http.Request) {
 				rw.WriteHeader(http.StatusUnauthorized)
 			},
-			err: fmt.Errorf(
-				"unauthorized action, please setup authentication for this server",
-			),
+			err: ErrUnauthorized,
+		},
+		{
+			name:         "client forbidden",
+			functionName: funcName,
+			namespace:    nsName,
+			handler: func(rw http.ResponseWriter, req *http.Request) {
+				rw.WriteHeader(http.StatusForbidden)
+			},
+			err: ErrForbidden,
 		},
 		{
 			name:         "unknown error",
@@ -292,11 +302,7 @@ func TestSdk_DeleteFunction(t *testing.T) {
 			handler: func(rw http.ResponseWriter, req *http.Request) {
 				http.Error(rw, "unknown error", http.StatusInternalServerError)
 			},
-			err: fmt.Errorf(
-				"server returned unexpected status code %d, message: %q",
-				http.StatusInternalServerError,
-				string("unknown error\n"),
-			),
+			err: ErrUnexpectedStatus,
 		},
 	}
 
@@ -313,7 +319,7 @@ func TestSdk_DeleteFunction(t *testing.T) {
 				test.namespace,
 			)
 
-			if !errors.Is(err, test.err) && err.Error() != test.err.Error() {
+			if !errors.Is(err, test.err) {
 				t.Fatalf("wanted %s, but got: %s", test.err, err)
 			}
 		})
@@ -334,7 +340,7 @@ func TestSdk_GetNamespace(t *testing.T) {
 			handler: func(rw http.ResponseWriter, req *http.Request) {
 				rw.WriteHeader(http.StatusNotFound)
 			},
-			err: fmt.Errorf("namespace %s not found", nsName),
+			err: ErrNotFound,
 		},
 		{
 			name:      "client not authorized",
@@ -342,9 +348,15 @@ func TestSdk_GetNamespace(t *testing.T) {
 			handler: func(rw http.ResponseWriter, req *http.Request) {
 				rw.WriteHeader(http.StatusUnauthorized)
 			},
-			err: fmt.Errorf(
-				"unauthorized action, please setup authentication for this server",
-			),
+			err: ErrUnauthorized,
+		},
+		{
+			name:      "client forbidden",
+			namespace: nsName,
+			handler: func(rw http.ResponseWriter, req *http.Request) {
+				rw.WriteHeader(http.StatusForbidden)
+			},
+			err: ErrForbidden,
 		},
 		{
 			name:      "unknown error",
@@ -352,11 +364,7 @@ func TestSdk_GetNamespace(t *testing.T) {
 			handler: func(rw http.ResponseWriter, req *http.Request) {
 				http.Error(rw, string("unknown error"), http.StatusInternalServerError)
 			},
-			err: fmt.Errorf(
-				"unexpected status code: %d, message: %q",
-				http.StatusInternalServerError,
-				string("unknown error\n"),
-			),
+			err: ErrUnexpectedStatus,
 		},
 	}
 
@@ -369,7 +377,7 @@ func TestSdk_GetNamespace(t *testing.T) {
 			client := NewClient(sU, nil, http.DefaultClient)
 			_, err := client.GetNamespace(context.Background(), test.namespace)
 
-			if !errors.Is(err, test.err) && err.Error() != test.err.Error() {
+			if !errors.Is(err, test.err) {
 				t.Fatalf("wanted %s, but got: %s", test.err, err)
 			}
 		})
@@ -412,9 +420,17 @@ func TestSdk_CreateNamespace(t *testing.T) {
 			handler: func(rw http.ResponseWriter, req *http.Request) {
 				rw.WriteHeader(http.StatusUnauthorized)
 			},
-			err: fmt.Errorf(
-				"unauthorized action, please setup authentication for this server",
-			),
+			err: ErrUnauthorized,
+		},
+		{
+			name: "client forbidden",
+			req: types.FunctionNamespace{
+				Name: nsName,
+			},
+			handler: func(rw http.ResponseWriter, req *http.Request) {
+				rw.WriteHeader(http.StatusForbidden)
+			},
+			err: ErrForbidden,
 		},
 		{
 			name: "unknown error",
@@ -424,11 +440,7 @@ func TestSdk_CreateNamespace(t *testing.T) {
 			handler: func(rw http.ResponseWriter, req *http.Request) {
 				http.Error(rw, string("unknown error"), http.StatusInternalServerError)
 			},
-			err: fmt.Errorf(
-				"unexpected status code: %d, message: %q",
-				http.StatusInternalServerError,
-				string("unknown error\n"),
-			),
+			err: ErrUnexpectedStatus,
 		},
 	}
 
@@ -441,7 +453,7 @@ func TestSdk_CreateNamespace(t *testing.T) {
 			client := NewClient(sU, nil, http.DefaultClient)
 			_, err := client.CreateNamespace(context.Background(), test.req)
 
-			if !errors.Is(err, test.err) && err.Error() != test.err.Error() {
+			if !errors.Is(err, test.err) {
 				t.Fatalf("wanted %s, but got: %s", test.err, err)
 			}
 		})
@@ -486,7 +498,7 @@ func TestSdk_UpdateNamespace(t *testing.T) {
 			handler: func(rw http.ResponseWriter, req *http.Request) {
 				rw.WriteHeader(http.StatusNotFound)
 			},
-			err: fmt.Errorf("namespace %s not found", nsName),
+			err: ErrNotFound,
 		},
 		{
 			name: "client not authorized",
@@ -496,9 +508,17 @@ func TestSdk_UpdateNamespace(t *testing.T) {
 			handler: func(rw http.ResponseWriter, req *http.Request) {
 				rw.WriteHeader(http.StatusUnauthorized)
 			},
-			err: fmt.Errorf(
-				"unauthorized action, please setup authentication for this server",
-			),
+			err: ErrUnauthorized,
+		},
+		{
+			name: "client forbidden",
+			req: types.FunctionNamespace{
+				Name: nsName,
+			},
+			handler: func(rw http.ResponseWriter, req *http.Request) {
+				rw.WriteHeader(http.StatusForbidden)
+			},
+			err: ErrForbidden,
 		},
 		{
 			name: "unknown error",
@@ -508,11 +528,7 @@ func TestSdk_UpdateNamespace(t *testing.T) {
 			handler: func(rw http.ResponseWriter, req *http.Request) {
 				http.Error(rw, string("unknown error"), http.StatusInternalServerError)
 			},
-			err: fmt.Errorf(
-				"unexpected status code: %d, message: %q",
-				http.StatusInternalServerError,
-				string("unknown error\n"),
-			),
+			err: ErrUnexpectedStatus,
 		},
 	}
 
@@ -525,7 +541,7 @@ func TestSdk_UpdateNamespace(t *testing.T) {
 			client := NewClient(sU, nil, http.DefaultClient)
 			_, err := client.UpdateNamespace(context.Background(), test.req)
 
-			if !errors.Is(err, test.err) && err.Error() != test.err.Error() {
+			if !errors.Is(err, test.err) {
 				t.Fatalf("wanted %s, but got: %s", test.err, err)
 			}
 		})
@@ -553,7 +569,7 @@ func TestSdk_DeleteNamespace(t *testing.T) {
 			handler: func(rw http.ResponseWriter, req *http.Request) {
 				rw.WriteHeader(http.StatusNotFound)
 			},
-			err: fmt.Errorf("namespace %s not found", nsName),
+			err: ErrNotFound,
 		},
 		{
 			name:      "client not authorized",
@@ -561,9 +577,15 @@ func TestSdk_DeleteNamespace(t *testing.T) {
 			handler: func(rw http.ResponseWriter, req *http.Request) {
 				rw.WriteHeader(http.StatusUnauthorized)
 			},
-			err: fmt.Errorf(
-				"unauthorized action, please setup authentication for this server",
-			),
+			err: ErrUnauthorized,
+		},
+		{
+			name:      "client forbidden",
+			namespace: nsName,
+			handler: func(rw http.ResponseWriter, req *http.Request) {
+				rw.WriteHeader(http.StatusForbidden)
+			},
+			err: ErrForbidden,
 		},
 		{
 			name:      "unknown error",
@@ -571,11 +593,7 @@ func TestSdk_DeleteNamespace(t *testing.T) {
 			handler: func(rw http.ResponseWriter, req *http.Request) {
 				http.Error(rw, string("unknown error"), http.StatusInternalServerError)
 			},
-			err: fmt.Errorf(
-				"unexpected status code: %d, message: %q",
-				http.StatusInternalServerError,
-				string("unknown error\n"),
-			),
+			err: ErrUnexpectedStatus,
 		},
 	}
 
@@ -588,7 +606,7 @@ func TestSdk_DeleteNamespace(t *testing.T) {
 			client := NewClient(sU, nil, http.DefaultClient)
 			err := client.DeleteNamespace(context.Background(), test.namespace)
 
-			if !errors.Is(err, test.err) && err.Error() != test.err.Error() {
+			if !errors.Is(err, test.err) {
 				t.Fatalf("wanted %s, but got: %s", test.err, err)
 			}
 		})
@@ -626,7 +644,19 @@ func TestSdk_CreateSecret(t *testing.T) {
 			handler: func(rw http.ResponseWriter, req *http.Request) {
 				rw.WriteHeader(http.StatusUnauthorized)
 			},
-			err: fmt.Errorf("unauthorized action, please setup authentication for this server"),
+			err: ErrUnauthorized,
+		},
+		{
+			name: "client forbidden",
+			req: types.Secret{
+				Name:      secretName,
+				Namespace: nsName,
+				Value:     secretValue,
+			},
+			handler: func(rw http.ResponseWriter, req *http.Request) {
+				rw.WriteHeader(http.StatusForbidden)
+			},
+			err: ErrForbidden,
 		},
 		{
 			name: "unknown error",
@@ -638,7 +668,7 @@ func TestSdk_CreateSecret(t *testing.T) {
 			handler: func(rw http.ResponseWriter, req *http.Request) {
 				http.Error(rw, string("unknown error"), http.StatusInternalServerError)
 			},
-			err: fmt.Errorf("unexpected status code: %d, message: %q", http.StatusInternalServerError, string("unknown error\n")),
+			err: ErrUnexpectedStatus,
 		},
 	}
 
@@ -651,7 +681,7 @@ func TestSdk_CreateSecret(t *testing.T) {
 			client := NewClient(sU, nil, http.DefaultClient)
 			_, err := client.CreateSecret(context.Background(), test.req)
 
-			if !errors.Is(err, test.err) && err.Error() != test.err.Error() {
+			if !errors.Is(err, test.err) {
 				t.Fatalf("wanted %s, but got: %s", test.err, err)
 			}
 		})
@@ -689,7 +719,19 @@ func TestSdk_UpdateSecret(t *testing.T) {
 			handler: func(rw http.ResponseWriter, req *http.Request) {
 				rw.WriteHeader(http.StatusUnauthorized)
 			},
-			err: fmt.Errorf("unauthorized action, please setup authentication for this server"),
+			err: ErrUnauthorized,
+		},
+		{
+			name: "client forbidden",
+			req: types.Secret{
+				Name:      secretName,
+				Namespace: nsName,
+				Value:     secretValue,
+			},
+			handler: func(rw http.ResponseWriter, req *http.Request) {
+				rw.WriteHeader(http.StatusForbidden)
+			},
+			err: ErrForbidden,
 		},
 		{
 			name: "unknown error",
@@ -701,7 +743,7 @@ func TestSdk_UpdateSecret(t *testing.T) {
 			handler: func(rw http.ResponseWriter, req *http.Request) {
 				http.Error(rw, string("unknown error"), http.StatusInternalServerError)
 			},
-			err: fmt.Errorf("unexpected status code: %d, message: %q", http.StatusInternalServerError, string("unknown error\n")),
+			err: ErrUnexpectedStatus,
 		},
 	}
 
@@ -714,7 +756,7 @@ func TestSdk_UpdateSecret(t *testing.T) {
 			client := NewClient(sU, nil, http.DefaultClient)
 			_, err := client.UpdateSecret(context.Background(), test.req)
 
-			if !errors.Is(err, test.err) && err.Error() != test.err.Error() {
+			if !errors.Is(err, test.err) {
 				t.Fatalf("wanted %s, but got: %s", test.err, err)
 			}
 		})
@@ -746,7 +788,7 @@ func TestSdk_DeleteSecret(t *testing.T) {
 			handler: func(rw http.ResponseWriter, req *http.Request) {
 				rw.WriteHeader(http.StatusNotFound)
 			},
-			err: fmt.Errorf("secret %s not found", secretName),
+			err: ErrNotFound,
 		},
 		{
 			name:       "client not authorized",
@@ -755,7 +797,16 @@ func TestSdk_DeleteSecret(t *testing.T) {
 			handler: func(rw http.ResponseWriter, req *http.Request) {
 				rw.WriteHeader(http.StatusUnauthorized)
 			},
-			err: fmt.Errorf("unauthorized action, please setup authentication for this server"),
+			err: ErrUnauthorized,
+		},
+		{
+			name:       "client forbidden",
+			secretName: secretName,
+			namespace:  nsName,
+			handler: func(rw http.ResponseWriter, req *http.Request) {
+				rw.WriteHeader(http.StatusForbidden)
+			},
+			err: ErrForbidden,
 		},
 		{
 			name:       "unknown error",
@@ -764,7 +815,7 @@ func TestSdk_DeleteSecret(t *testing.T) {
 			handler: func(rw http.ResponseWriter, req *http.Request) {
 				http.Error(rw, "unknown error", http.StatusInternalServerError)
 			},
-			err: fmt.Errorf("server returned unexpected status code %d, message: %q", http.StatusInternalServerError, string("unknown error\n")),
+			err: ErrUnexpectedStatus,
 		},
 	}
 
@@ -777,7 +828,7 @@ func TestSdk_DeleteSecret(t *testing.T) {
 			client := NewClient(sU, nil, http.DefaultClient)
 			err := client.DeleteSecret(context.Background(), test.secretName, test.namespace)
 
-			if !errors.Is(err, test.err) && err.Error() != test.err.Error() {
+			if !errors.Is(err, test.err) {
 				t.Fatalf("wanted %s, but got: %s", test.err, err)
 			}
 		})


### PR DESCRIPTION
## Description

Add `ErrNotFound`, `ErrUnauthorized`, `ErrForbidden`, and `ErrUnexpectedStatus` sentinel errors so callers can use `errors.Is` to distinguish error cases returned by Client methods.

- Add status code switches to `GetNamespaces`, `GetFunctions`, `GetFunction`, `GetInfo`, and `GetSecrets` which previously had no or only partial status code checks
- Update all existing methods to wrap sentinel errors consistently
- Handle `403 Forbidden` responses with `ErrForbidden` across all methods

We chose sentinel errors specifically to avoid diverging from the current method call signatures. Callers can use `errors.Is` without any changes to return types:

```go
errors.Is(err, sdk.ErrNotFound)
errors.Is(err, sdk.ErrUnauthorized)
errors.Is(err, sdk.ErrForbidden)
errors.Is(err, sdk.ErrUnexpectedStatus)
```

**Breaking change:** Error messages returned by Client methods have changed. Code that matches on exact error strings will need to be updated to use `errors.Is` with the new sentinel errors instead.

## Motivation and context

The OpenFaaS dashboard uses this SDK and needed to distinguish between different API error conditions—particularly authorization errors—to handle them differently for display in the UI. Without sentinel errors, callers had to resort to fragile string matching on error messages which made it difficult to reliably detect specific error conditions.

## How has this been tested

- Unit tests have been updated to use `errors.Is` with the new sentinel errors and new test cases for `403 Forbidden` have been added across all methods
- The updated SDK was vendored into the OpenFaaS dashboard and used while making the UI changes to verify the new error handling works end to end
